### PR TITLE
Use node20 instead of node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,5 +34,5 @@ inputs:
     description: 'Command to run inside VM. The specified command must be an absolute path. Note that the specified command is not run inside a shell by default. If you want a shell, use /bin/bash -c "$SHELL_CMD_HERE".'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Usage of the action caused the GitHub Actions framework to emit a warning ala:
> The following actions uses Node.js version which is deprecated and
> will be forced to run on node20: danobi/vmtest-action@v0.6.

As per the associated blog entry [0], Node.js 20 was already forced on everybody on 2024-06-03. Hence, the switch to Node.js 20 should effectively be a no-op. Do it anyway to silence the warning.

Closes: #3

[0] https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/