### PR TITLE
Let Dependabot manage vmtest version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    versioning-strategy: auto
+    directory: /
+    schedule:
+      interval: daily

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+# A dummy Cargo project file enabling semi-automated vmtest version
+# management via Dependabot.
+
+[package]
+name = "vmtest-version"
+
+[dependencies]
+# This file is parsed ghetto-style, assuming the `vmtest` version being
+# located on the last line and it using <major>.<minor>.<patch> syntax.
+vmtest = "0.12.0"


### PR DESCRIPTION
It's easy to forget to update the vmtest version used by the action when a new vmtest release is cut. In an attempt to semi-automate the process, use Dependabot to manage said version in a dummy Cargo manifest. It will run daily and create a pull request if a new version is encountered. In the action we then pick up the version managed in this manifest when installing the vmtest binary.